### PR TITLE
Increase the z-index on hover.

### DIFF
--- a/d2l-card.html
+++ b/d2l-card.html
@@ -127,9 +127,11 @@ Polymer-based web components for card
 				border: none;
 				box-shadow: 0 4px 8px 0 rgba(0,0,0,0.03);
 			}
+
 			:host(:hover),
 			:host([subtle]:hover) {
 				transform: translateY(-4px);
+				z-index: 1;
 			}
 			:host(:hover) {
 				box-shadow: 0 2px 14px 1px rgba(0,0,0,0.06);
@@ -137,6 +139,7 @@ Polymer-based web components for card
 			:host([subtle]:hover) {
 				box-shadow: 0 4px 18px 2px rgba(0,0,0,0.06);
 			}
+
 			:host([active]) {
 				border-color: rgba(0, 111, 191, 0.4);
 				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);


### PR DESCRIPTION
So, the parents `z-index` limits the children `z-index`. [https://stackoverflow.com/a/7814337] Well at least that guy believes it to be true. 

This property is observed when I enabled the tooltips. The tooltips would be hidden under other cards to the right. To fix it I found increasing the `z-index` on card hover worked.

I tried to fix it in the tooltip repo but I couldn't figure it out. If you have any ideas on a cleaner fix that would be awesome.

Menus still work as expected.