### PR TITLE
Componentize the loading shimmer from the image tile for use in card

### DIFF
--- a/d2l-card-header-loading-shimmer.html
+++ b/d2l-card-header-loading-shimmer.html
@@ -1,0 +1,59 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+
+<!--
+`d2l-card-header-loading-shimmer` is a Polymer-based web component for implementing a loading shimmer for a card header.
+-->
+<dom-module id="d2l-card-header-loading-shimmer">
+	<template strip-whitespace>
+		<style>
+			:host([hidden]) {
+				display: none;
+			}
+
+			@keyframes loadingShimmer {
+				0% { transform: translate3d(-100%, 0, 0); }
+				100% { transform: translate3d(100%, 0, 0); }
+			}
+
+			.d2l-card-header-loading-shimmer {
+				background-color: var(--d2l-color-regolith);
+				border-radius: 7px 7px 0 0;
+				box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
+				overflow: hidden;
+				position: relative;
+				height: inherit;
+			}
+
+			.d2l-card-header-loading-shimmer::after {
+				animation: loadingShimmer 1.5s ease-in-out infinite;
+				background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
+				background-color: var(--d2l-color-regolith);
+				content: '';
+				height: 100%;
+				left: 0;
+				position: absolute;
+				top: 0;
+				width: 100%;
+			}
+		</style>
+
+		<div hidden$="[[!loading]]" class="d2l-card-header-loading-shimmer"></div>
+		<div class="loaded-content" hidden$="[[loading]]">
+			<slot></slot>
+		</div>
+	</template>
+	<script>
+	'use strict';
+
+	Polymer({
+		is: 'd2l-card-header-loading-shimmer',
+		properties: {
+			loading: {
+				type: Boolean,
+				value: false
+			}
+		}
+	});
+	</script>
+</dom-module>

--- a/d2l-card-loading-shimmer.html
+++ b/d2l-card-loading-shimmer.html
@@ -39,7 +39,7 @@
 		</style>
 
 		<div hidden$="[[!loading]]" class="d2l-card-loading-shimmer"></div>
-		<div class="loaded-content" hidden$="[[loading]]">
+		<div hidden$="[[loading]]">
 			<slot></slot>
 		</div>
 	</template>

--- a/d2l-card-loading-shimmer.html
+++ b/d2l-card-loading-shimmer.html
@@ -2,9 +2,9 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 
 <!--
-`d2l-card-header-loading-shimmer` is a Polymer-based web component for implementing a loading shimmer for a card header.
+`d2l-card-loading-shimmer` is a Polymer-based web component for implementing a loading shimmer for a card.
 -->
-<dom-module id="d2l-card-header-loading-shimmer">
+<dom-module id="d2l-card-loading-shimmer">
 	<template strip-whitespace>
 		<style>
 			:host([hidden]) {
@@ -16,7 +16,7 @@
 				100% { transform: translate3d(100%, 0, 0); }
 			}
 
-			.d2l-card-header-loading-shimmer {
+			.d2l-card-loading-shimmer {
 				background-color: var(--d2l-color-regolith);
 				border-radius: 7px 7px 0 0;
 				box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
@@ -25,7 +25,7 @@
 				height: inherit;
 			}
 
-			.d2l-card-header-loading-shimmer::after {
+			.d2l-card-loading-shimmer::after {
 				animation: loadingShimmer 1.5s ease-in-out infinite;
 				background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
 				background-color: var(--d2l-color-regolith);
@@ -38,7 +38,7 @@
 			}
 		</style>
 
-		<div hidden$="[[!loading]]" class="d2l-card-header-loading-shimmer"></div>
+		<div hidden$="[[!loading]]" class="d2l-card-loading-shimmer"></div>
 		<div class="loaded-content" hidden$="[[loading]]">
 			<slot></slot>
 		</div>
@@ -47,7 +47,7 @@
 	'use strict';
 
 	Polymer({
-		is: 'd2l-card-header-loading-shimmer',
+		is: 'd2l-card-loading-shimmer',
 		properties: {
 			loading: {
 				type: Boolean,


### PR DESCRIPTION
I want to start moving some of the `image-tile` users to instead use `d2l-card`, most of the tile consumers use the "loading shimmer" it provides, so rather than replicate the styling across repos, it seemed like a good idea to create a component.

Simply slot in your header content, and if the "loading" attribute is there, you'll see the loading shimmer instead of the slotted content.