### PR TITLE
make the footer full width so that the bottom icons can be centered

### DIFF
--- a/d2l-card.html
+++ b/d2l-card.html
@@ -110,6 +110,8 @@ Polymer-based web components for card
 				flex: none;
 				padding: 1.2rem 0.8rem 0.6rem 0.8rem;
 				z-index: 2;
+				width: 100%;
+				box-sizing: border-box;
 			}
 			.d2l-card-footer-hidden .d2l-card-footer {
 				@apply --d2l-offscreen;

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -112,7 +112,13 @@ Polymer-based web components for card
 				z-index: 2;
 				width: 100%;
 				box-sizing: border-box;
+				pointer-events: none;
 			}
+
+			.d2l-card-footer ::slotted([slot="footer"]) {
+				pointer-events: all;
+			}
+
 			.d2l-card-footer-hidden .d2l-card-footer {
 				@apply --d2l-offscreen;
 				height: auto;

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -121,6 +121,7 @@ Polymer-based web components for card
 
 			.d2l-card-footer-hidden .d2l-card-footer {
 				@apply --d2l-offscreen;
+				box-sizing: content-box;
 				height: auto;
 			}
 			/* P2-shadow */
@@ -291,7 +292,9 @@ Polymer-based web components for card
 				}
 				var container = Polymer.dom(this.root).querySelector('.d2l-card-container');
 				var entry = entries[0];
-				if (entry.contentRect.height === 0 && !container.classList.contains('d2l-card-footer-hidden')) {
+				// firefox has a rounding error when calculating the height of the contentRect with `box-sizing: border-box;`
+				// so check for numbers which are close to 0 as well
+				if (entry.contentRect.height < 0.0001 && !container.classList.contains('d2l-card-footer-hidden')) {
 					fastdom.mutate(function() {
 						container.classList.add('d2l-card-footer-hidden');
 					});

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -294,7 +294,7 @@ Polymer-based web components for card
 				var entry = entries[0];
 				// firefox has a rounding error when calculating the height of the contentRect with `box-sizing: border-box;`
 				// so check for numbers which are close to 0 as well
-				if (entry.contentRect.height < 0.0001 && !container.classList.contains('d2l-card-footer-hidden')) {
+				if (entry.contentRect.height < 1 && !container.classList.contains('d2l-card-footer-hidden')) {
 					fastdom.mutate(function() {
 						container.classList.add('d2l-card-footer-hidden');
 					});


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14077760/49026134-a90b9e00-f162-11e8-9f92-834d03209ce1.png)

After:
![image](https://user-images.githubusercontent.com/14077760/49026196-d9ebd300-f162-11e8-9e12-513e22db01c9.png)

Did a quick check on the course tile and there are no visual differences that I could see

(Multiple of the `design.d2l` examples show a centered menu like this)
![image](https://user-images.githubusercontent.com/14077760/49026528-b2493a80-f163-11e8-8edb-adda27c874d7.png)
![image](https://user-images.githubusercontent.com/14077760/49026534-b5dcc180-f163-11e8-936d-1ea810452525.png)
