### PR TITLE
Use a web component compatible polyfill for ResizeObserver

### DIFF
--- a/d2l-card.js
+++ b/d2l-card.js
@@ -17,7 +17,7 @@ import 'd2l-link/d2l-link-behavior.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-polymer-behaviors/d2l-dom.js';
 import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
-import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "d2l-link": "BrightspaceUI/link#semver:^5",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "resize-observer-polyfill": "^1.5.0",
+    "d2l-resize-aware": "git://github.com/BrightspaceUI/resize-aware.git#semver:^1",
     "@polymer/polymer": "^3.0.0"
   }
 }


### PR DESCRIPTION
The ResizeObserver polyfill being used here has [an issue](https://github.com/que-etc/resize-observer-polyfill/issues/51) in that it fails to respond to resizes caused by changes in the shadow DOM of webcomponents.

This PR switches to using a polyfill that correctly handles web components.