### PR TITLE
Fix for opting out of underline in card meta content.

### DIFF
--- a/d2l-card-content-meta.js
+++ b/d2l-card-content-meta.js
@@ -28,7 +28,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-content-meta">
 				line-height: 1rem;
 			}
 			:host span {
-				display: inline-block;
+				display: inline-block; /* extra inline-block helps reset display context to opt-out of underline */
 			}
 		</style>
 		<span><slot></slot></span>

--- a/d2l-card-content-meta.js
+++ b/d2l-card-content-meta.js
@@ -27,11 +27,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-content-meta">
 				display: inline-block;
 				line-height: 1rem;
 			}
+			:host span {
+				display: inline-block;
+			}
 		</style>
-		<slot></slot>
+		<span><slot></slot></span>
 	</template>
 
-	
+
 
 </dom-module>`;
 


### PR DESCRIPTION
When inside a flex context, and when underline would normally be inherited, it's not possible to simply use `inline-block` to opt-out of the underline style.  This change adds a span which apparently helps to "reset" the display context so that this work-around works.  Note: [d2l-enrollment-card](https://github.com/BrightspaceHypermediaComponents/enrollments/blob/master/components/d2l-enrollment-card/d2l-enrollment-card.js#L194) uses such a  flex context for card content, and while it seems like it's not serving a purpose in its case, it's a valid scenario.