### PR TITLE
using iron-icon instead of d2l-icon with iron-iconset-svg

### DIFF
--- a/d2l-card-footer-link.js
+++ b/d2l-card-footer-link.js
@@ -13,7 +13,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import 'd2l-colors/d2l-colors.js';
 import 'fastdom/fastdom.js';
-import 'd2l-icons/d2l-icon.js';
+import '@polymer/iron-icon/iron-icon.js';
 import 'd2l-link/d2l-link-behavior.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
@@ -57,11 +57,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-footer-link">
 				width: 100%;
 				z-index: 1;
 			}
-			a.d2l-focusable[href]:focus + .d2l-card-footer-link-content > d2l-icon,
-			a.d2l-focusable[href]:hover + .d2l-card-footer-link-content > d2l-icon {
+			a.d2l-focusable[href]:focus + .d2l-card-footer-link-content > iron-icon,
+			a.d2l-focusable[href]:hover + .d2l-card-footer-link-content > iron-icon {
 				color: var(--d2l-color-celestine);
 			}
-			d2l-icon {
+			iron-icon {
 				height: 0.9rem;
 				width: 0.9rem;
 			}
@@ -100,7 +100,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-footer-link">
 			<span class="d2l-card-footer-link-text">[[text]]</span>
 		</a>
 		<div class="d2l-card-footer-link-content">
-			<d2l-icon icon="[[icon]]"></d2l-icon>
+			<iron-icon icon="[[icon]]"></iron-icon>
 			<div class="d2l-card-footer-link-secondary-text" aria-hidden="true" hidden="">[[secondaryText]]</div>
 		</div>
 	</template>

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -148,13 +148,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 							<div slot="content"><div style="text-align: center;">Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
 							<div slot="footer">
-								<d2l-card-footer-link id="googleDriveLink1" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
+								<d2l-card-footer-link id="googleDriveLink1" icon="d2l-tier1:d2l-icon-google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 								<d2l-tooltip for="googleDriveLink1">Go to Google Drive</d2l-tooltip>
-								<d2l-card-footer-link id="rssFeedLink1" icon="d2l-tier1:rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
+								<d2l-card-footer-link id="rssFeedLink1" icon="d2l-tier1:d2l-icon-rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
 								<d2l-tooltip for="rssFeedLink1">RSS Feed</d2l-tooltip>
-								<d2l-card-footer-link id="outcomesLink1" icon="d2l-tier1:outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
+								<d2l-card-footer-link id="outcomesLink1" icon="d2l-tier1:d2l-icon-outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
 								<d2l-tooltip for="outcomesLink1">Outcomes</d2l-tooltip>
-								<d2l-card-footer-link id="assignmentsLink1" icon="d2l-tier1:assignments" text="Assignments" secondary-text="3"></d2l-card-footer-link>
+								<d2l-card-footer-link id="assignmentsLink1" icon="d2l-tier1:d2l-icon-assignments" text="Assignments" secondary-text="3"></d2l-card-footer-link>
 								<d2l-tooltip position="top" style="width: 100%;" for="assignmentsLink1">You have 3 assignments due tomorrow.</d2l-tooltip>
 							</div>
 						</d2l-card>
@@ -167,11 +167,11 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 							<div slot="content" style="text-align: center;">Grade 2</div>
 							<div slot="footer">
-								<d2l-card-footer-link id="googleDriveLink2" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
+								<d2l-card-footer-link id="googleDriveLink2" icon="d2l-tier1:d2l-icon-google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 								<d2l-tooltip for="googleDriveLink2">Go to Google Drive</d2l-tooltip>
-								<d2l-card-footer-link id="rssFeedLink2" icon="d2l-tier1:rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
+								<d2l-card-footer-link id="rssFeedLink2" icon="d2l-tier1:d2l-icon-rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
 								<d2l-tooltip for="rssFeedLink2">RSS Feed</d2l-tooltip>
-								<d2l-card-footer-link id="outcomesLink2" icon="d2l-tier1:outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
+								<d2l-card-footer-link id="outcomesLink2" icon="d2l-tier1:d2l-icon-outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
 								<d2l-tooltip for="outcomesLink2">Outcomes</d2l-tooltip>
 							</div>
 						</d2l-card>
@@ -236,13 +236,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 						<div slot="content"><div style="text-align: center;">Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
 						<div slot="footer">
-							<d2l-card-footer-link id="googleDriveLink3" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
+							<d2l-card-footer-link id="googleDriveLink3" icon="d2l-tier1:d2l-icon-google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 							<d2l-tooltip for="googleDriveLink3">Go to Google Drive</d2l-tooltip>
-							<d2l-card-footer-link id="rssFeedLink3" icon="d2l-tier1:rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
+							<d2l-card-footer-link id="rssFeedLink3" icon="d2l-tier1:d2l-icon-rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
 							<d2l-tooltip for="rssFeedLink3">RSS Feed</d2l-tooltip>
-							<d2l-card-footer-link id="outcomesLink3" icon="d2l-tier1:outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
+							<d2l-card-footer-link id="outcomesLink3" icon="d2l-tier1:d2l-icon-outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
 							<d2l-tooltip for="outcomesLink3">Outcomes</d2l-tooltip>
-							<d2l-card-footer-link id="assignmentsLink3" icon="d2l-tier1:assignments" text="Assignments" secondary-text="3"></d2l-card-footer-link>
+							<d2l-card-footer-link id="assignmentsLink3" icon="d2l-tier1:d2l-icon-assignments" text="Assignments" secondary-text="3"></d2l-card-footer-link>
 							<d2l-tooltip position="top" style="width: 100%;" for="assignmentsLink3">You have 3 assignments due tomorrow.</d2l-tooltip>
 						</div>
 					</d2l-card>
@@ -255,11 +255,11 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 						<div slot="content" style="text-align: center;">Grade 2</div>
 						<div slot="footer">
-							<d2l-card-footer-link id="googleDriveLink4" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
+							<d2l-card-footer-link id="googleDriveLink4" icon="d2l-tier1:d2l-icon-google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 							<d2l-tooltip for="googleDriveLink4">Go to Google Drive</d2l-tooltip>
-							<d2l-card-footer-link id="rssFeedLink4" icon="d2l-tier1:rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
+							<d2l-card-footer-link id="rssFeedLink4" icon="d2l-tier1:d2l-icon-rss" text="RSS Feed" secondary-text="1"></d2l-card-footer-link>
 							<d2l-tooltip for="rssFeedLink4">RSS Feed</d2l-tooltip>
-							<d2l-card-footer-link id="outcomesLink4" icon="d2l-tier1:outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
+							<d2l-card-footer-link id="outcomesLink4" icon="d2l-tier1:d2l-icon-outcomes" text="Outcomes" secondary-text="5"></d2l-card-footer-link>
 							<d2l-tooltip for="outcomesLink4">Outcomes</d2l-tooltip>
 						</div>
 					</d2l-card>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "main": "d2l-card.js",
   "dependencies": {
+    "@polymer/iron-icon": "^3.0.1",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "fastdom": "^1.0.8",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",


### PR DESCRIPTION
Temporarily using `iron-icon` instead of `d2l-icon` here until we can switch it to use Lit core icons or until the `OrganizationUpdatesMixin` it depends on stops using a custom `iron-iconset-svg`.