### PR TITLE
US114012 add center align option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Then add the `d2l-card`, provide an `href` if relevant, and provide elements for
 * `text` (required): accessible text for the card (will be announced when AT user focused on card)
 * `href` (optional): the location for the primary action/navigation
 * `subtle` (optional): used for a subtle aesthetic on non-white backgrounds
+* `center-content` (optional): used to style the card's content as horizontally centered
 * other link properties as defined by [D2L.PolymerBehaviors.Link.Behavior](https://github.com/BrightspaceUI/link/blob/master/d2l-link-behavior.html)
 
 ## Developing, Testing and Contributing

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then add the `d2l-card`, provide an `href` if relevant, and provide elements for
 * `text` (required): accessible text for the card (will be announced when AT user focused on card)
 * `href` (optional): the location for the primary action/navigation
 * `subtle` (optional): used for a subtle aesthetic on non-white backgrounds
-* `center-content` (optional): used to style the card's content as horizontally centered
+* `align-center` (optional): used to style the card's content and footer as horizontally centered
 * other link properties as defined by [D2L.PolymerBehaviors.Link.Behavior](https://github.com/BrightspaceUI/link/blob/master/d2l-link-behavior.html)
 
 ## Developing, Testing and Contributing

--- a/d2l-card.js
+++ b/d2l-card.js
@@ -72,7 +72,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			.d2l-card-content {
 				padding: 1.2rem 0.8rem 0 0.8rem;
 			}
-			.d2l-card-content[alignCenter] {
+			:host([align-center]) .d2l-card-content {
 				text-align: center;
 			}
 
@@ -109,7 +109,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 				box-sizing: border-box;
 				pointer-events: none;
 			}
-			.d2l-card-footer[alignCenter] {
+			:host([align-center]) .d2l-card-footer {
 				text-align: center;
 			}
 
@@ -177,10 +177,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			<div class="d2l-card-link-container">
 				<div class="d2l-card-header"><slot name="header"></slot></div>
 				<div class="d2l-card-badge"><slot name="badge"></slot></div>
-				<div class="d2l-card-content" alignCenter$="[[alignCenter]]"><slot name="content"></slot></div>
+				<div class="d2l-card-content"><slot name="content"></slot></div>
 			</div>
 			<div class="d2l-card-actions"><slot name="actions"></slot></div>
-			<div class="d2l-card-footer" alignCenter$="[[alignCenter]]"><slot name="footer"></slot></div>
+			<div class="d2l-card-footer"><slot name="footer"></slot></div>
 		</div>
 	</template>
 

--- a/d2l-card.js
+++ b/d2l-card.js
@@ -72,7 +72,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			.d2l-card-content {
 				padding: 1.2rem 0.8rem 0 0.8rem;
 			}
-			.d2l-card-content[centerContent] {
+			.d2l-card-content[alignCenter] {
 				text-align: center;
 			}
 
@@ -108,6 +108,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 				width: 100%;
 				box-sizing: border-box;
 				pointer-events: none;
+			}
+			.d2l-card-footer[alignCenter] {
+				text-align: center;
 			}
 
 			.d2l-card-footer ::slotted([slot="footer"]) {
@@ -174,10 +177,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			<div class="d2l-card-link-container">
 				<div class="d2l-card-header"><slot name="header"></slot></div>
 				<div class="d2l-card-badge"><slot name="badge"></slot></div>
-				<div class="d2l-card-content" centerContent$="[[centerContent]]"><slot name="content"></slot></div>
+				<div class="d2l-card-content" alignCenter$="[[alignCenter]]"><slot name="content"></slot></div>
 			</div>
 			<div class="d2l-card-actions"><slot name="actions"></slot></div>
-			<div class="d2l-card-footer"><slot name="footer"></slot></div>
+			<div class="d2l-card-footer" alignCenter$="[[alignCenter]]"><slot name="footer"></slot></div>
 		</div>
 	</template>
 
@@ -213,7 +216,7 @@ Polymer({
 		/**
 		 * Indicates whether to apply text-align:center to the content slot
 		 */
-		centerContent: {
+		alignCenter: {
 			type: Boolean,
 			reflectToAttribute: true
 		}

--- a/d2l-card.js
+++ b/d2l-card.js
@@ -72,6 +72,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			.d2l-card-content {
 				padding: 1.2rem 0.8rem 0 0.8rem;
 			}
+			.d2l-card-content[centerContent] {
+				text-align: center;
+			}
+
 			.d2l-card-footer-hidden .d2l-card-content {
 				padding-bottom: 1.2rem;
 			}
@@ -170,7 +174,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card">
 			<div class="d2l-card-link-container">
 				<div class="d2l-card-header"><slot name="header"></slot></div>
 				<div class="d2l-card-badge"><slot name="badge"></slot></div>
-				<div class="d2l-card-content"><slot name="content"></slot></div>
+				<div class="d2l-card-content" centerContent$="[[centerContent]]"><slot name="content"></slot></div>
 			</div>
 			<div class="d2l-card-actions"><slot name="actions"></slot></div>
 			<div class="d2l-card-footer"><slot name="footer"></slot></div>
@@ -203,6 +207,14 @@ Polymer({
 		 */
 		text: {
 			type: String,
+			reflectToAttribute: true
+		},
+
+		/**
+		 * Indicates whether to apply text-align:center to the content slot
+		 */
+		centerContent: {
+			type: Boolean,
 			reflectToAttribute: true
 		}
 

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -105,25 +105,25 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				<template>
 					<div class="subtle-demo">
 
-						<d2l-card subtle="" text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" center-content text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<div slot="badge" class="badge">
 								<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/Stick_Figure.svg/340px-Stick_Figure.svg.png">
 							</div>
-							<div slot="content" style="text-align: center;">Image Badge</div>
+							<div slot="content">Image Badge</div>
 						</d2l-card>
 
-						<d2l-card subtle="" text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" center-content text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<div class="badge-status" slot="badge">
 								<d2l-status-indicator text="Success" state="success"></d2l-status-indicator>
 							</div>
-							<div slot="content" style="text-align: center;">Status Badge</div>
+							<div slot="content">Status Badge</div>
 						</d2l-card>
 
-						<d2l-card subtle="" text="No Link" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" center-content text="No Link" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
-							<div slot="content" style="text-align: center;">No Link</div>
+							<div slot="content">No Link</div>
 						</d2l-card>
 
 					</div>
@@ -136,7 +136,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				<template>
 					<div class="subtle-demo">
 
-						<d2l-card subtle="" text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" center-content text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content>
@@ -146,7 +146,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 									</d2l-dropdown-content>
 							</d2l-dropdown-more>
 							<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-							<div slot="content"><div style="text-align: center;">Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
+							<div slot="content"><div>Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
 							<div slot="footer">
 								<d2l-card-footer-link id="googleDriveLink1" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 								<d2l-tooltip for="googleDriveLink1">Go to Google Drive</d2l-tooltip>
@@ -159,13 +159,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							</div>
 						</d2l-card>
 
-						<d2l-card subtle="" text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" center-content text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-low-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
 							</d2l-dropdown-more>
 							<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-							<div slot="content" style="text-align: center;">Grade 2</div>
+							<div slot="content">Grade 2</div>
 							<div slot="footer">
 								<d2l-card-footer-link id="googleDriveLink2" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 								<d2l-tooltip for="googleDriveLink2">Go to Google Drive</d2l-tooltip>
@@ -176,13 +176,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							</div>
 						</d2l-card>
 
-						<d2l-card subtle="" text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" center-content text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
 							</d2l-dropdown-more>
 							<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-							<div slot="content" style="text-align: center;">Painting</div>
+							<div slot="content">Painting</div>
 							<d2l-button slot="footer" style="width: 100%;">Shiny Button</d2l-button>
 						</d2l-card>
 
@@ -195,25 +195,25 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 
-					<d2l-card text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+					<d2l-card center-content text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<div slot="badge" class="badge">
 							<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/Stick_Figure.svg/340px-Stick_Figure.svg.png">
 						</div>
-						<div slot="content" style="text-align: center;">Image Badge</div>
+						<div slot="content">Image Badge</div>
 					</d2l-card>
 
-					<d2l-card text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+					<d2l-card center-content text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<div class="badge-status" slot="badge">
 							<d2l-status-indicator text="Success" state="success"></d2l-status-indicator>
 						</div>
-						<div slot="content" style="text-align: center;">Status Badge</div>
+						<div slot="content">Status Badge</div>
 					</d2l-card>
 
-					<d2l-card text="No Link" style="width: 245px; height: 280px;">
+					<d2l-card center-content text="No Link" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
-						<div slot="content" style="text-align: center;">No Link</div>
+						<div slot="content">No Link</div>
 					</d2l-card>
 
 				</template>
@@ -224,7 +224,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 
-					<d2l-card text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
+					<d2l-card center-content text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content>
@@ -234,7 +234,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 								</d2l-dropdown-content>
 						</d2l-dropdown-more>
 						<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-						<div slot="content"><div style="text-align: center;">Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
+						<div slot="content"><div>Hydrology</div><d2l-card-content-meta>This is some extra meta data that will fill the content slot of the card.</d2l-card-content-meta></div>
 						<div slot="footer">
 							<d2l-card-footer-link id="googleDriveLink3" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 							<d2l-tooltip for="googleDriveLink3">Go to Google Drive</d2l-tooltip>
@@ -247,13 +247,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						</div>
 					</d2l-card>
 
-					<d2l-card text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
+					<d2l-card center-content text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-low-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
 						</d2l-dropdown-more>
 						<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-						<div slot="content" style="text-align: center;">Grade 2</div>
+						<div slot="content">Grade 2</div>
 						<div slot="footer">
 							<d2l-card-footer-link id="googleDriveLink4" icon="d2l-tier1:google-drive" text="Google Drive" secondary-text="99+" href="https://www.google.ca/drive/"></d2l-card-footer-link>
 							<d2l-tooltip for="googleDriveLink4">Go to Google Drive</d2l-tooltip>
@@ -264,13 +264,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						</div>
 					</d2l-card>
 
-					<d2l-card text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
+					<d2l-card center-content text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
 						</d2l-dropdown-more>
 						<d2l-button-icon slot="actions" translucent="" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
-						<div slot="content" style="text-align: center;">Painting</div>
+						<div slot="content">Painting</div>
 						<div slot="footer">Secondary Actions</div>
 					</d2l-card>
 

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				<template>
 					<div class="subtle-demo">
 
-						<d2l-card subtle="" center-content text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" align-center text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<div slot="badge" class="badge">
 								<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/Stick_Figure.svg/340px-Stick_Figure.svg.png">
@@ -113,7 +113,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							<div slot="content">Image Badge</div>
 						</d2l-card>
 
-						<d2l-card subtle="" center-content text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" align-center text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<div class="badge-status" slot="badge">
 								<d2l-status-indicator text="Success" state="success"></d2l-status-indicator>
@@ -121,7 +121,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							<div slot="content">Status Badge</div>
 						</d2l-card>
 
-						<d2l-card subtle="" center-content text="No Link" style="width: 245px; height: 280px;">
+						<d2l-card subtle="" align-center text="No Link" style="width: 245px; height: 280px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<div slot="content">No Link</div>
 						</d2l-card>
@@ -136,7 +136,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				<template>
 					<div class="subtle-demo">
 
-						<d2l-card subtle="" center-content text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" align-center text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content>
@@ -159,7 +159,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							</div>
 						</d2l-card>
 
-						<d2l-card subtle="" center-content text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" align-center text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-low-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
@@ -176,7 +176,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							</div>
 						</d2l-card>
 
-						<d2l-card subtle="" center-content text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
+						<d2l-card subtle="" align-center text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
 							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
 							<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 									<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
@@ -195,7 +195,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 
-					<d2l-card center-content text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+					<d2l-card align-center text="Image Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<div slot="badge" class="badge">
 							<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/Stick_Figure.svg/340px-Stick_Figure.svg.png">
@@ -203,7 +203,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<div slot="content">Image Badge</div>
 					</d2l-card>
 
-					<d2l-card center-content text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
+					<d2l-card align-center text="Status Badge" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<div class="badge-status" slot="badge">
 							<d2l-status-indicator text="Success" state="success"></d2l-status-indicator>
@@ -211,7 +211,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<div slot="content">Status Badge</div>
 					</d2l-card>
 
-					<d2l-card center-content text="No Link" style="width: 245px; height: 280px;">
+					<d2l-card align-center text="No Link" style="width: 245px; height: 280px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<div slot="content">No Link</div>
 					</d2l-card>
@@ -224,7 +224,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 
-					<d2l-card center-content text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
+					<d2l-card align-center text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content>
@@ -247,7 +247,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						</div>
 					</d2l-card>
 
-					<d2l-card center-content text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
+					<d2l-card align-center text="Grade 2" href="https://en.wikipedia.org/wiki/Second_grade" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-low-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>
@@ -264,7 +264,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						</div>
 					</d2l-card>
 
-					<d2l-card center-content text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
+					<d2l-card align-center text="Painting" href="https://en.wikipedia.org/wiki/Painting" style="width: 245px; height: 300px;">
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent="" visible-on-ancestor="" text="Open!">
 								<d2l-dropdown-content><div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div></d2l-dropdown-content>

--- a/test/d2l-card.html
+++ b/test/d2l-card.html
@@ -36,6 +36,18 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="cardWithAlignCenter">
+			<template>
+				<d2l-card align-center text="accessible title" href="https://google.com" style="width: 300px; height: 500px;">
+					<div slot="content">
+						<div>title</div>
+						<d2l-card-content-meta>some other info</d2l-card-content-meta>
+					</div>
+					<div slot="footer"><div id="footerContent">footer stuff</div></div>
+				</d2l-card>
+			</template>
+		</test-fixture>
+
 		<script type="module">
 import 'd2l-polymer-behaviors/d2l-dom-focus.js';
 import '../d2l-card.js';
@@ -104,6 +116,21 @@ describe('<d2l-card>', function() {
 			});
 		});
 
+	});
+
+	describe('card with center-align attribute', function() {
+
+		beforeEach(function(done) {
+			card = fixture('cardWithAlignCenter');
+			raf(done);
+		});
+
+		it('Applies center align to the content and footer of the card', function() {
+			var footer = card._getContainer().querySelector('.d2l-card-footer');
+			var content = card._getContainer().querySelector('.d2l-card-content');
+			expect(window.getComputedStyle(footer).getPropertyValue('text-align')).to.equal('center');
+			expect(window.getComputedStyle(content).getPropertyValue('text-align')).to.equal('center');
+		});
 	});
 
 });

--- a/test/d2l-card.html
+++ b/test/d2l-card.html
@@ -87,6 +87,13 @@ describe('<d2l-card>', function() {
 			expect(D2L.Dom.Focus.getComposedActiveElement()).to.equal(link);
 		});
 
+		it('has text-align:center on the content slot after attribute center-content is applied', function() {
+			var content = card._getContainer().querySelector('.d2l-card-content');
+			expect(window.getComputedStyle(content, null).getPropertyValue('text-align')).to.not.equal('center');
+			card.setAttribute('center-content', '');
+			expect(window.getComputedStyle(content, null).getPropertyValue('text-align')).to.equal('center');
+		});
+
 	});
 
 	describe('card with footer', function() {

--- a/test/d2l-card.html
+++ b/test/d2l-card.html
@@ -87,13 +87,6 @@ describe('<d2l-card>', function() {
 			expect(D2L.Dom.Focus.getComposedActiveElement()).to.equal(link);
 		});
 
-		it('has text-align:center on the content slot after attribute center-content is applied', function() {
-			var content = card._getContainer().querySelector('.d2l-card-content');
-			expect(window.getComputedStyle(content, null).getPropertyValue('text-align')).to.not.equal('center');
-			card.setAttribute('center-content', '');
-			expect(window.getComputedStyle(content, null).getPropertyValue('text-align')).to.equal('center');
-		});
-
 	});
 
 	describe('card with footer', function() {


### PR DESCRIPTION
### Context
This PR adds an optional boolean attribute `align-center` to the `d2l-card`.
Applying this attribute will apply css styling to center align the `content` and `footer` slots of the card.

This change is being made to match the design documentation at http://design.d2l/components/cards/ and to provide a convenient mechanism to apply this change to current and future cards. The cards used in Discover will immediately adopt this attribute.

### Quality
- All demos have been updated to use this attribute, rather than directly apply styling to the content slot. It seems to appear as expected in all demos. Note that demos did not previously apply this to the footer, only the content, but the design page above suggests it should be applied to both.
- I created tests to ensure the styling is aligned to center on the content and footer slots after applying the `align-center` attribute.