### PR TITLE
Align footers to the centre of cards

### DIFF
--- a/d2l-card-footer-link.js
+++ b/d2l-card-footer-link.js
@@ -38,7 +38,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-footer-link">
 				left: auto;
 				margin-left: 0.3rem;
 				margin-right: 0;
-				right: -0.6rem;
+				right: 0.15rem;
 			}
 			.d2l-card-footer-link-content {
 				display: inline-block;

--- a/d2l-card-footer-link.js
+++ b/d2l-card-footer-link.js
@@ -27,7 +27,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-card-footer-link">
 		<style include="d2l-offscreen-shared-styles">
 			:host {
 				display: inline-block;
-				left: -0.6rem;
+				left: 0.15rem;
 				margin-right: 0.3rem;
 				position: relative;
 			}


### PR DESCRIPTION
https://rally1.rallydev.com/#/detail/defect/403655625400?fdp=true

1 line CSS change to fix the alignment of ` d2l-card-footer-link` icons in a card

Before:
![cc0](https://user-images.githubusercontent.com/23266447/90920060-41bd6500-e3ad-11ea-8d59-0adfc3ce9803.JPG)

After:
![cc1](https://user-images.githubusercontent.com/23266447/90920078-4a15a000-e3ad-11ea-9696-c7e4be941965.JPG)